### PR TITLE
feat: add .matome11 class and update .parallax-container height

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -20,6 +20,12 @@
     width: 368px;
 }
 
+/* matome11 */
+.matome11{
+    width: 1200px;
+    max-width: 100%;
+}
+
 
 
 /* 実践02 */
@@ -53,7 +59,7 @@
 /* 実践03 - パララックス効果 */
 .parallax-container {
     position: relative;
-    height: 800px;
+    height: 480px;
     overflow: hidden;
     margin: 50px 0;
 }


### PR DESCRIPTION
Add .matome11 class with width: 1200px and max-width: 100%

Change .parallax-container height from 800px to 480px

Related classes use percentage-based sizing that adapts correctly

Fixes #7

Generated with [Claude Code](https://claude.ai/code)